### PR TITLE
[conf.py] Fixed the tex render by overriding the mathjax_path.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,9 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+#  Override mathjax_path to correct tex render.
+mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+
 mathjax_config = {                  
     "TeX": {                        
         "Macros": {                 


### PR DESCRIPTION
Hi @mmmarinho,

Currently, the TeX rendering is not working. This PR fixes it. According to the [documentation](https://www.sphinx-doc.org/en/master/usage/extensions/math.html#confval-mathjax3_config), we may need to override the mathjax_path in the `conf.py` file. Such modification is working on my local tests. 

Best regards, 

Juancho

