### PR TITLE
This PR fixes warnings related to short title underlines and proposes a solution to the TeX rendering issue

### DIFF
--- a/docs/_static/mathjax_config.html
+++ b/docs/_static/mathjax_config.html
@@ -1,0 +1,13 @@
+<script type="text/x-mathjax-config">
+    MathJax.Hub.Config({
+    extensions: ["tex2jax.js"],
+    jax: ["input/TeX", "output/HTML-CSS"],
+    tex2jax: {
+      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
+      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
+      processEscapes: true
+    },
+    "HTML-CSS": { availableFonts: ["TeX"] }
+    });
+    </script>
+<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>

--- a/docs/advanced/vfi.rst
+++ b/docs/advanced/vfi.rst
@@ -1,5 +1,5 @@
 Vector-field inequalities
-########################
+##########################
 .. note::
   This section is based on the results presented in :cite:`Marinho2019`.
 
@@ -56,7 +56,7 @@ As an usage example, suppose that we are using the :code:`KukaYoubot` robot
 
 
 Robot-point to point distance Jacobian, :math:`\mymatrix J_{\quat t,\quat p}`
-------------------------------------
+-----------------------------------------------------------------------------
 .. note:: 
    Mathematically defined in Eq. (22) of :cite:`Marinho2019`.
 
@@ -67,7 +67,7 @@ The Jacobian relating the joint velocities with the derivative of the squared-di
    result = DQ_Kinematics.point_to_point_distance_jacobian(translation_jacobian, robot_point, workspace_point)
 
 Robot-point to line distance Jacobian, :math:`\mymatrix J_{\quat t,\quat l}`
-------------------------------------
+----------------------------------------------------------------------------
 .. note:: 
    Mathematically defined in Eq. (32) of :cite:`Marinho2019`.
 
@@ -79,7 +79,7 @@ The Jacobian relating the joint velocities with the derivative of the squared-di
 
 
 Robot-line to point distance Jacobian, :math:`\mymatrix J_{\quat l,\quat p}`
-------------------------------------
+----------------------------------------------------------------------------
 .. note:: 
    This method provides a generalized version of Eq. (34) of :cite:`Marinho2019` to any line in the manipulator.
 
@@ -91,7 +91,7 @@ The Jacobian relating the joint velocities with the derivative of the squared-di
 
 
 Robot-line to line distance Jacobian, :math:`\mymatrix J_{\quat l,\quat l}`
-------------------------------------
+---------------------------------------------------------------------------
 .. note:: 
    This method provides a generalized version of Eq. (48) of :cite:`Marinho2019` to any line in the manipulator.
 
@@ -103,7 +103,7 @@ The Jacobian relating the joint velocities with the derivative of the squared-di
    
    
 Robot-plane to point distance Jacobian, :math:`\mymatrix J_{\quat \pi,\quat l}`
-------------------------------------
+-------------------------------------------------------------------------------
 .. note:: 
    This method provides a generalized version of Eq. (56) of :cite:`Marinho2019` to any plane in the manipulator.
 
@@ -115,7 +115,7 @@ The Jacobian relating the joint velocities with the derivative of the distance b
    
    
 Robot-point to plane distance Jacobian, :math:`\mymatrix J_{\quat p,\quat \pi}`
-------------------------------------
+-------------------------------------------------------------------------------
 .. note:: 
    Mathematically defined in Eq. (59) of :cite:`Marinho2019`.
 

--- a/docs/advanced/vfi.rst
+++ b/docs/advanced/vfi.rst
@@ -1,5 +1,9 @@
 Vector-field inequalities
 ##########################
+
+.. raw:: html
+    :file: ../_static/mathjax_config.html
+
 .. note::
   This section is based on the results presented in :cite:`Marinho2019`.
 

--- a/docs/advanced/vfi.rst
+++ b/docs/advanced/vfi.rst
@@ -1,9 +1,6 @@
 Vector-field inequalities
 ##########################
 
-.. raw:: html
-    :file: ../_static/mathjax_config.html
-
 .. note::
   This section is based on the results presented in :cite:`Marinho2019`.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -1,9 +1,6 @@
 Basics
 ======================================
 
-.. raw:: html
-    :file: _static/mathjax_config.html
-
 .. note::
    We use the mathematical notation of :cite:`adorno2017` unless otherwise stated.
 

--- a/docs/basics.rst
+++ b/docs/basics.rst
@@ -1,6 +1,9 @@
 Basics
 ======================================
 
+.. raw:: html
+    :file: _static/mathjax_config.html
+
 .. note::
    We use the mathematical notation of :cite:`adorno2017` unless otherwise stated.
 

--- a/docs/basics/cpp.rst
+++ b/docs/basics/cpp.rst
@@ -1,8 +1,11 @@
 C++11 Basics
 ####################
+
+.. raw:: html
+    :file: ../_static/mathjax_config.html
   
 Preliminaries
-============
+==============
 All code in this section expects you to have the :code:`include` and :code:`using` in the beginning of your file
 
 .. code-block:: cpp
@@ -12,10 +15,10 @@ All code in this section expects you to have the :code:`include` and :code:`usin
   using namespace DQ_robotics;
 
 Binary Operations
-============
+==================
 
 Preliminaries
--------------
+--------------
 
 Suppose you have the dual quaternions
 

--- a/docs/basics/cpp.rst
+++ b/docs/basics/cpp.rst
@@ -1,8 +1,5 @@
 C++11 Basics
 ####################
-
-.. raw:: html
-    :file: ../_static/mathjax_config.html
   
 Preliminaries
 ==============

--- a/docs/basics/python.rst
+++ b/docs/basics/python.rst
@@ -1,8 +1,11 @@
 Python3 Basics
 ####################
+
+.. raw:: html
+    :file: ../_static/mathjax_config.html
   
 Preliminaries
-============
+==============
 All code in this section expects you to have the followoing import in the beginning of your file
 
 .. code-block:: python
@@ -10,10 +13,10 @@ All code in this section expects you to have the followoing import in the beginn
   from dqrobotics import *
 
 Binary Operations
-============
+==================
 
 Preliminaries
--------------
+--------------
 
 Suppose you have the dual quaternions
 

--- a/docs/basics/python.rst
+++ b/docs/basics/python.rst
@@ -1,8 +1,5 @@
 Python3 Basics
 ####################
-
-.. raw:: html
-    :file: ../_static/mathjax_config.html
   
 Preliminaries
 ==============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,11 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
+rst_prolog = """.. raw:: html
+    :file: _static/mathjax_config.html
+"""
+
+
 #  Override mathjax_path to correct tex render.
 mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 


### PR DESCRIPTION
@dqrobotics/developers 

Hi @bvadorno and @mmmarinho, 

This PR proposes a (temporal?) solution to the current TeX rendering issue. I found out that when I included [in-line configuration options](https://docs.mathjax.org/en/v2.7-latest/configuration.html) in each file that uses Tex, the rendering worked well (At least locally).  For instance, in the `basics.rst` file, I included the following

```rst
.. raw:: html
    :file: _static/mathjax_config.html
```
 where, the file `mathjax_config.html` contains the following:

```html
<script type="text/x-mathjax-config">
    MathJax.Hub.Config({
    extensions: ["tex2jax.js"],
    jax: ["input/TeX", "output/HTML-CSS"],
    tex2jax: {
      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
      processEscapes: true
    },
    "HTML-CSS": { availableFonts: ["TeX"] }
    });
    </script>
<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
```

Result:

<img width="1095" alt="Screenshot 2024-05-27 at 17 14 44" src="https://github.com/dqrobotics/dqrobotics.github.io/assets/23158313/7e4f16bf-67a0-4fcd-9691-af58445cf145">

I wonder if this strategy works in the main DQ robotics site (since previous solutions I proposed failed :confused:).

Best regards, 

 
Juancho