### PR TITLE
This PR aims to fix the tex-render issue (attempt 3) 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,14 @@
+version: "2"
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
 python:
-  version: 3
-requirements_file: docs/requirements.txt
+  install:
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py
 

--- a/docs/_static/mathjax_config.html
+++ b/docs/_static/mathjax_config.html
@@ -10,7 +10,7 @@ MathJax = {
       imk: ["{\\hat{k}}"],
       dual: ["{\\varepsilon}"],
       mymatrix: ["\\bf{#1}",1],
-      dq: ["{\\underline{\bf{#1}}}",1],
+      dq: ["{\\underline{\\bf{#1}}}",1],
     }
   }
 };

--- a/docs/_static/mathjax_config.html
+++ b/docs/_static/mathjax_config.html
@@ -1,13 +1,19 @@
-<script type="text/x-mathjax-config">
-    MathJax.Hub.Config({
-    extensions: ["tex2jax.js"],
-    jax: ["input/TeX", "output/HTML-CSS"],
-    tex2jax: {
-      inlineMath: [ ['$','$'], ["\\(","\\)"] ],
-      displayMath: [ ['$$','$$'], ["\\[","\\]"] ],
-      processEscapes: true
-    },
-    "HTML-CSS": { availableFonts: ["TeX"] }
-    });
-    </script>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script>
+MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    macros: {
+      RR: "{\\bf R}",
+      quat: ["{\\bf #1}", 1],
+      imi: ["{\\hat{\\imath}}"],
+      imj: ["{\\hat{\\jmath}}"],
+      imk: ["{\\hat{k}}"],
+      dual: ["{\\varepsilon}"],
+      mymatrix: ["\\bf{#1}",1],
+    }
+  }
+};
+</script>
+<script type="text/javascript" id="MathJax-script" async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>

--- a/docs/_static/mathjax_config.html
+++ b/docs/_static/mathjax_config.html
@@ -10,6 +10,7 @@ MathJax = {
       imk: ["{\\hat{k}}"],
       dual: ["{\\varepsilon}"],
       mymatrix: ["\\bf{#1}",1],
+      dq: ["{\\underline{\bf{#1}}}",1],
     }
   }
 };

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,21 +63,3 @@ rst_prolog = """.. raw:: html
 """
 
 
-#  Override mathjax_path to correct tex render.
-#mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
-
-"""
-mathjax_config = {                  
-    "TeX": {                        
-        "Macros": {                 
-            "imi": '{\\hat{\\imath}}',
-	    "imj": '{\\hat{\\jmath}}',
-	    "imk": '{\\hat{k}}',
-            "dual": '{\\varepsilon}',
-            "dq": ['{\\underline{\b{#1}}}',1],
-            "quat": ['\b{#1}',1],
-            "mymatrix": ['\b{#1}',1],
-            }                       
-        }                           
-    }
-"""

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,8 +64,9 @@ rst_prolog = """.. raw:: html
 
 
 #  Override mathjax_path to correct tex render.
-mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
+#mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
+"""
 mathjax_config = {                  
     "TeX": {                        
         "Macros": {                 
@@ -78,4 +79,5 @@ mathjax_config = {
             "mymatrix": ['\b{#1}',1],
             }                       
         }                           
-    }    
+    }
+"""


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho and @bvadorno, 

My previous PR didn't work, despite working on local builds. I believe the macros are not being recognized when the site is deployed. Therefore, I modified the `mathjax_config.html` and included the macros there.  I really do not know how the main DQ Robotics site is being deployed. It looks like is using `ReadTheDocs`. However, I required modifications in the `.readthedocs.yml` file to correctly build and deploy the site. 

Anyway, I created my [project](https://test-dqroboticsgithubio.readthedocs.io/en/latest/basics.html) on `ReadTheDocs` instead of testing this PR locally. It is working well.

I would like to know if these modifications work when merged.

Best regards, 

Juancho



https://test-dqroboticsgithubio.readthedocs.io/en/latest/basics.html