### PR TITLE
This PR aims to fix the tex-render issue (Attempt 3)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,13 @@
-python:
-  version: 3
-requirements_file: docs/requirements.txt
+version: "2"
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+
+sphinx:
+  configuration: docs/conf.py

--- a/docs/_static/mathjax_config.html
+++ b/docs/_static/mathjax_config.html
@@ -1,0 +1,20 @@
+<script>
+MathJax = {
+  tex: {
+    inlineMath: [['$', '$'], ['\\(', '\\)']],
+    macros: {
+      RR: "{\\bf R}",
+      quat: ["{\\bf #1}", 1],
+      imi: ["{\\hat{\\imath}}"],
+      imj: ["{\\hat{\\jmath}}"],
+      imk: ["{\\hat{k}}"],
+      dual: ["{\\varepsilon}"],
+      mymatrix: ["\\bf{#1}",1],
+      dq: ["{\\underline{\\bf{#1}}}",1],
+    }
+  }
+};
+</script>
+<script type="text/javascript" id="MathJax-script" async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,19 +58,7 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-#  Override mathjax_path to correct tex render.
-mathjax_path = 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
-
-mathjax_config = {                  
-    "TeX": {                        
-        "Macros": {                 
-            "imi": '{\\hat{\\imath}}',
-	    "imj": '{\\hat{\\jmath}}',
-	    "imk": '{\\hat{k}}',
-            "dual": '{\\varepsilon}',
-            "dq": ['{\\underline{\b{#1}}}',1],
-            "quat": ['\b{#1}',1],
-            "mymatrix": ['\b{#1}',1],
-            }                       
-        }                           
-    }    
+#  This includes a custom HTML in each rst file. Such HTML defines Mathjax configurations and TeX macros.
+rst_prolog = """.. raw:: html
+    :file: _static/mathjax_config.html
+"""


### PR DESCRIPTION
@dqrobotics/developers 

Hi @mmmarinho and @bvadorno, 

My previous PR didn't work, despite working on local builds. I believe the macros are not being recognized when the site is deployed. Therefore, I modified the `mathjax_config.html` and included the macros there.  I really do not know how the main DQ Robotics site is being deployed. It looks like is using `ReadTheDocs`. However, I required modifications in the `.readthedocs.yml` file to correctly build and deploy the site. 

I created a [project](https://test-dqroboticsgithubio.readthedocs.io/en/latest/basics.html) on `ReadTheDocs` instead of testing this PR locally. It is working well.

I would like to know if these modifications work when merged.

Best regards, 

Juancho